### PR TITLE
Add Opcodes for Branching Instructions

### DIFF
--- a/src/csc612m/integrating/project/MainFrame.java
+++ b/src/csc612m/integrating/project/MainFrame.java
@@ -25,10 +25,12 @@ public class MainFrame extends javax.swing.JFrame {
     DefaultTableModel memory_table;
     DefaultTableModel program_table;
     HashMap<String, Integer> register_alias_map;
+    HashMap<String, String> data_segment_map;
     
     public MainFrame() {
         initComponents();
         pipeline = new Pipeline();
+        data_segment_map = new HashMap<String, String>();
         
         register_alias_map = new HashMap<String, Integer>() {{ //this is used when the instruction is invoking the alias name which will point to a row number (the integer value)
             put("t0", 5);
@@ -69,11 +71,13 @@ public class MainFrame extends javax.swing.JFrame {
             Vector cell = new Vector(); //this stores the value of each 'cell' per address row
             int[] decimal_to_binary = Convert.IntDecimalToBinary(i, 12); //12 bits == 2048 (according to specs)
             String binary_to_hex = Convert.BinaryToHex(decimal_to_binary);
-            cell.add("0x"+binary_to_hex);
+            cell.add("0x"+binary_to_hex); //this is just the label
             for (int j = 4; j < 32; j+=4) //add half bytes
             {
                 binary_to_hex = Convert.BinaryToHex(Convert.IntDecimalToBinary(0, 12));
                 cell.add(binary_to_hex);
+                String memory_hex = Convert.BinaryToHex(Convert.IntDecimalToBinary(i+j, 12));
+//                data_segment_map.put(memory_hex, binary_to_hex);
             }
             this.memory_table.addRow(cell);
         }
@@ -344,20 +348,20 @@ public class MainFrame extends javax.swing.JFrame {
             Vector cell = new Vector(); //this stores the value of each 'cell' per address row
             int[] decimal_to_binary = Convert.IntDecimalToBinary(i, 13); //13 bits == 4096 (according to specs)
             String binary_to_hex = Convert.BinaryToHex(decimal_to_binary);
-//            String instruction_opcode = opcode.GenerateOpcode(lines[j], jTableRegister);
             cell.add("0x"+binary_to_hex);
-            cell.add("");
+            cell.add(""); //empty opcodes column for now
             cell.add(lines[j]);
             this.program_table.addRow(cell);
         }
         
         DefaultTableModel program_model = (DefaultTableModel)jTableProgram.getModel();
-
+        
+        //assign opcodes after loading the instructions in memory
         for (int i = 0; i < jTableProgram.getRowCount(); i++)
         {
-            Object pre_rd_value = jTableProgram.getValueAt(i, 0);
-            String hex_value = (pre_rd_value == null) ? "" : pre_rd_value.toString();
-            String full_opcode = opcode.GenerateOpcode(lines[i]);
+//            Object pre_rd_value = jTableProgram.getValueAt(i, 0);
+//            String hex_value = (pre_rd_value == null) ? "" : pre_rd_value.toString();
+            String full_opcode = opcode.GenerateOpcode(lines[i], i);
             program_model.setValueAt(full_opcode, i, 1);
         }
       

--- a/src/csc612m/integrating/project/MainFrame.java
+++ b/src/csc612m/integrating/project/MainFrame.java
@@ -29,7 +29,6 @@ public class MainFrame extends javax.swing.JFrame {
     public MainFrame() {
         initComponents();
         pipeline = new Pipeline();
-        opcode = new Opcode();
         
         register_alias_map = new HashMap<String, Integer>() {{ //this is used when the instruction is invoking the alias name which will point to a row number (the integer value)
             put("t0", 5);
@@ -337,6 +336,7 @@ public class MainFrame extends javax.swing.JFrame {
 
     public void PopulateProgramTextSegmentAddress()
     {
+        opcode = new Opcode(jTableRegister, jTableProgram);
         lines = jEditorPane1.getText().split("\n");
         this.program_table = (DefaultTableModel)jTableProgram.getModel();
         for (int i = 0, j = 0; j < lines.length && i < 4096; i+=4, j++)
@@ -344,11 +344,21 @@ public class MainFrame extends javax.swing.JFrame {
             Vector cell = new Vector(); //this stores the value of each 'cell' per address row
             int[] decimal_to_binary = Convert.IntDecimalToBinary(i, 13); //13 bits == 4096 (according to specs)
             String binary_to_hex = Convert.BinaryToHex(decimal_to_binary);
-            String instruction_opcode = opcode.GenerateOpcode(lines[j], jTableRegister);
+//            String instruction_opcode = opcode.GenerateOpcode(lines[j], jTableRegister);
             cell.add("0x"+binary_to_hex);
-            cell.add(instruction_opcode);
+            cell.add("");
             cell.add(lines[j]);
             this.program_table.addRow(cell);
+        }
+        
+        DefaultTableModel program_model = (DefaultTableModel)jTableProgram.getModel();
+
+        for (int i = 0; i < jTableProgram.getRowCount(); i++)
+        {
+            Object pre_rd_value = jTableProgram.getValueAt(i, 0);
+            String hex_value = (pre_rd_value == null) ? "" : pre_rd_value.toString();
+            String full_opcode = opcode.GenerateOpcode(lines[i]);
+            program_model.setValueAt(full_opcode, i, 1);
         }
       
     }

--- a/src/csc612m/integrating/project/Opcode.java
+++ b/src/csc612m/integrating/project/Opcode.java
@@ -131,7 +131,7 @@ public class Opcode {
     //we should probably dissect the pipeline's execution as each function (etc. Decode = 1 function, PC = 1 function, 
     //so we can reflect the state of the simulator back to the GUI
     
-    public String GenerateOpcode(String line)
+    public String GenerateOpcode(String line, int current_line)
     {
         String full_opcode = "";
         binary_opcode = new int[32];
@@ -176,7 +176,7 @@ public class Opcode {
                 case "lw":
                     rd_table_row = GetRegisterTableRow(params[0]);
                     rs1_table_row = GetRegisterTableRow(params[1]);
-                    hexa_value = GetHexaValueFromTableRow(rs1_table_row, jTableRegister);
+                    hexa_value = GetHexaValueFromTableRow(rs1_table_row);
                     rs1_binary = Convert.HexaToBinary(hexa_value);
                     rd_binary = Convert.DecimalToBinary(Integer.toString(rd_table_row)); 
                     
@@ -222,9 +222,9 @@ public class Opcode {
                     rd_binary = Convert.DecimalToBinary(Integer.toString(rd_table_row)); 
                     rs1_table_row = GetRegisterTableRow(params[1]);
                     rs2_table_row = GetRegisterTableRow(params[2]);
-                    hexa_value = GetHexaValueFromTableRow(rs1_table_row, jTableRegister);
+                    hexa_value = GetHexaValueFromTableRow(rs1_table_row);
                     rs1_binary = Convert.HexaToBinary(hexa_value);
-                    hexa_value = GetHexaValueFromTableRow(rs2_table_row, jTableRegister);
+                    hexa_value = GetHexaValueFromTableRow(rs2_table_row);
                     rs2_binary = Convert.HexaToBinary(hexa_value);
                     
                     AddBinaryToOpcode(binary_opcode, instruction_opcode, 6, 0);
@@ -245,7 +245,7 @@ public class Opcode {
                     rd_table_row = GetRegisterTableRow(params[0]);
                     rd_binary = Convert.DecimalToBinary(Integer.toString(rd_table_row)); 
                     rs1_table_row = GetRegisterTableRow(params[1]);
-                    hexa_value = GetHexaValueFromTableRow(rs1_table_row, jTableRegister);
+                    hexa_value = GetHexaValueFromTableRow(rs1_table_row);
                     rs1_binary = Convert.HexaToBinary(hexa_value);
                     int[] imm_binary = Convert.DecimalToBinary(params[2], 12);
                     
@@ -263,7 +263,7 @@ public class Opcode {
                     rd_table_row = GetRegisterTableRow(params[0]);
                     rd_binary = Convert.DecimalToBinary(Integer.toString(rd_table_row)); 
                     rs1_table_row = GetRegisterTableRow(params[1]);
-                    hexa_value = GetHexaValueFromTableRow(rs1_table_row, jTableRegister);
+                    hexa_value = GetHexaValueFromTableRow(rs1_table_row);
                     rs1_binary = Convert.HexaToBinary(hexa_value);
                     
                     int[] shamt_binary = Convert.DecimalToBinary(params[2]);
@@ -276,6 +276,34 @@ public class Opcode {
                     
                     binary_opcode = InvertBinary(binary_opcode);
                     full_opcode = Convert.BinaryToHex(binary_opcode);
+                    break;
+                //BEQ, BNE, BLT, BGE
+                case "beq":
+                case "bne":
+                case "blt":
+                case "bge":
+                    rs1_table_row = GetRegisterTableRow(params[1]);
+                    hexa_value = GetHexaValueFromTableRow(rs1_table_row);
+                    rs1_binary = Convert.HexaToBinary(hexa_value);
+                    
+                    String current_line_hexadecimal = GetProgramHexValueFromTableRow(current_line);
+                    String branch_hexadecimal = FindLabelHexValueFromTableRow(params[2]); //params 3 is the target branch label
+                    
+                    //convert hexadecimals to decimal for easier computation
+                    int current_line_integer = Convert.HexToDecimal(current_line_hexadecimal);
+                    int branch_integer = Convert.HexToDecimal(branch_hexadecimal);
+                    
+                    //compute for the hexadecimal difference of label and current source
+                    int result = branch_integer - current_line_integer;
+                    int[] result_binary = Convert.IntDecimalToBinary(result, 12);
+                    
+                    AddBinaryToOpcode(binary_opcode, instruction_opcode, 6, 0);
+                    AddBinaryToOpcode(binary_opcode, rd_binary, 11, 7);
+                    AddBinaryToOpcode(binary_opcode, funct3_opcode, 14, 12);
+                    AddBinaryToOpcode(binary_opcode, rs1_binary, 19, 15);
+                    AddBinaryToOpcode(binary_opcode, rs2_binary, 24, 20);
+                    AddBinaryToOpcode(binary_opcode, funct7_opcode, 31, 25);
+                    
                     break;
                 default: //check if its a label
                     Pattern pattern = Pattern.compile("\\w:", Pattern.CASE_INSENSITIVE);
@@ -358,7 +386,7 @@ public class Opcode {
         return table_row;
     }
     
-    public String GetHexaValueFromTableRow(int table_row, JTable jTableRegister)
+    public String GetHexaValueFromTableRow(int table_row)
     {
         Object pre_rd_value = jTableRegister.getValueAt(table_row, 2);
         String rd_value = (pre_rd_value == null) ? "" : pre_rd_value.toString();
@@ -366,6 +394,37 @@ public class Opcode {
         rd_value = rd_value.replace("0x", ""); //removes the radix
         
         return rd_value;
+    }
+    
+    public String GetProgramHexValueFromTableRow(int table_row)
+    {
+        Object pre_rd_value = jTableProgram.getValueAt(table_row, 0);
+        String rd_value = (pre_rd_value == null) ? "" : pre_rd_value.toString();
+        
+        rd_value = rd_value.replace("0x", ""); //removes the radix
+        
+        return rd_value;
+    }
+    
+    public String FindLabelHexValueFromTableRow(String label)
+    {
+        String found_label = "";
+        for (int i = 0; i < jTableProgram.getRowCount(); i++)
+        {
+            String temp_label = label + ":"; //because the target label has a colon in it, this'll make things easier
+            Object pre_current_label = jTableProgram.getValueAt(i, 2); //index 2 is the actual label row itself
+            String current_label = (pre_current_label == null) ? "" : pre_current_label.toString();
+            
+            if (temp_label.equals(current_label))
+            {
+                Object pre_found_label = jTableProgram.getValueAt(i, 0); //index 0 is the hexadecimal value of the label
+                found_label = (pre_found_label == null) ? "" : pre_found_label.toString();
+                
+                found_label = found_label.replace("0x", "");
+                break;
+            }
+        }
+        return found_label;
     }
     
     public int[] GetIMMBinaryOfOffset(String full_param)

--- a/src/csc612m/integrating/project/Opcode.java
+++ b/src/csc612m/integrating/project/Opcode.java
@@ -7,6 +7,7 @@ package csc612m.integrating.project;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JTable;
@@ -282,6 +283,8 @@ public class Opcode {
                 case "bne":
                 case "blt":
                 case "bge":
+                    funct7_opcode = new int[7]; //ignore funct7 mapping for branches
+                    
                     rs1_table_row = GetRegisterTableRow(params[1]);
                     hexa_value = GetHexaValueFromTableRow(rs1_table_row);
                     rs1_binary = Convert.HexaToBinary(hexa_value);
@@ -297,13 +300,28 @@ public class Opcode {
                     int result = branch_integer - current_line_integer;
                     int[] result_binary = Convert.IntDecimalToBinary(result, 12);
                     
+                    rd_binary[4] = result_binary[1]; //res binary 1 == imm[11]
+                    for (int i = 11, j = 3; i >= 8; i--, j--)
+                    {
+                        rd_binary[j] = result_binary[i];
+                    }
+                    
+                    for (int i = 7; i >=2 ; i--)
+                    {
+                        funct7_opcode[i-1] = result_binary[i];
+                    }
+                    
+                    funct7_opcode[0] = result_binary[0];                    
+                    
                     AddBinaryToOpcode(binary_opcode, instruction_opcode, 6, 0);
-                    AddBinaryToOpcode(binary_opcode, rd_binary, 11, 7);
+                    AddBinaryToOpcode(binary_opcode, rd_binary, 11, 7); //to change
                     AddBinaryToOpcode(binary_opcode, funct3_opcode, 14, 12);
                     AddBinaryToOpcode(binary_opcode, rs1_binary, 19, 15);
                     AddBinaryToOpcode(binary_opcode, rs2_binary, 24, 20);
                     AddBinaryToOpcode(binary_opcode, funct7_opcode, 31, 25);
                     
+                    binary_opcode = InvertBinary(binary_opcode);
+                    full_opcode = Convert.BinaryToHex(binary_opcode);
                     break;
                 default: //check if its a label
                     Pattern pattern = Pattern.compile("\\w:", Pattern.CASE_INSENSITIVE);


### PR DESCRIPTION
Also modified the assembly function where it loads all instructions into the program without opcodes yet.

And then load in the opcodes for all instructions.

This is so when we encounter a branch instruction, we are able to compute both the target and source address properly.